### PR TITLE
PYI-848 Permit running browser tests in headless mode

### DIFF
--- a/.github/workflows/smoketTest.yml
+++ b/.github/workflows/smoketTest.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Step 3 - Build with Maven
         env:
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital/
+          BROWSER: chrome-headless
         run:  mvn clean test -D"cucumber.filter.tags=@address_smoke"

--- a/src/test/java/gov/di_ipv_core/utilities/ConfigurationReader.java
+++ b/src/test/java/gov/di_ipv_core/utilities/ConfigurationReader.java
@@ -29,6 +29,10 @@ public class ConfigurationReader {
         return properties.getProperty(keyName);
     }
 
+    public static String getBrowser() {
+        return System.getenv("BROWSER") != null ? System.getenv("BROWSER") : "chrome";
+    }
+
     public static String getOrchestratorUrl() {
 
         String orchestratorStubUrl = System.getenv("ORCHESTRATOR_STUB_URL");

--- a/src/test/java/gov/di_ipv_core/utilities/Driver.java
+++ b/src/test/java/gov/di_ipv_core/utilities/Driver.java
@@ -28,9 +28,7 @@ public class Driver {
         //if this thread doesn't have driver - create it and add to pool
         if (driverPool.get() == null) {
 
-//            if we pass the driver from terminal then use that one
-//           if we do not pass the driver from terminal then use the one properties file
-            String browser = System.getProperty("browser") != null ? browser = System.getProperty("browser") : ConfigurationReader.get("browser");
+            String browser = ConfigurationReader.getBrowser();
 
             switch (browser) {
                 case "chrome":


### PR DESCRIPTION
Make selection of the browser via an environment variables for simpler
selection with a default to 'chrome'. Update the GitHub action to run in
headless mode because at present it is failing.

## Notes

The mvn test in the github action now passes: https://github.com/alphagov/di-ipv-core-tests/runs/5767559154?check_suite_focus=true#step:4:10756. Before the test was failing and the build was succeeding, we still need to address that.