### PR TITLE
PYIC-890: Add smoke test for the real passport CRI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,3 +76,14 @@ task addressStubSmoke() {
         }
     }
 }
+
+task passportCriSmoke() {
+    dependsOn assemble, compileTestJava
+    doLast {
+        javaexec {
+            main = "io.cucumber.core.cli.Main"
+            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
+            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@passportSmoke']
+        }
+    }
+}

--- a/src/test/java/gov/di_ipv_core/pages/IpvCoreFrontPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/IpvCoreFrontPage.java
@@ -11,8 +11,14 @@ public class IpvCoreFrontPage {
         PageFactory.initElements(Driver.get(), this);
     }
 
+    @FindBy (xpath = "//h1")
+    public WebElement h1;
+
     @FindBy (xpath = "//a[normalize-space()='Address (Stub)']")
     public WebElement AddressStub;
+
+    @FindBy (xpath = "//a[normalize-space()='ukPassport']")
+    public WebElement UkPassport;
 
     @FindBy (xpath = "//span[@class='govuk-details__summary-text']")
     public WebElement CredentialAttributes;

--- a/src/test/java/gov/di_ipv_core/pages/PassportPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/PassportPage.java
@@ -17,8 +17,11 @@ public class PassportPage {
     @FindBy(id="surname")
     public WebElement Surname;
 
-    @FindBy(id="givenNames")
-    public WebElement GivenNames;
+    @FindBy(id="firstName")
+    public WebElement FirstName;
+
+    @FindBy(id="middleNames")
+    public WebElement MiddleNames;
 
     @FindBy(id="dateOfBirth-day")
     public WebElement birthDay;

--- a/src/test/java/gov/di_ipv_core/step_definitions/AddressStubSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/AddressStubSmokeSteps.java
@@ -16,64 +16,22 @@ public class AddressStubSmokeSteps {
 
     String myData;
 
-    @Given("I am on Orchestrator Stub")
-    public void i_am_on_orchestrator_stub() {
-        Driver.get().get(ConfigurationReader.getOrchestratorUrl());
-        BrowserUtils.waitForPageToLoad(10);
-    }
-    @When("I click on Debug route")
-    public void i_click_on_debug_route() {
-        new OrchestratorStubPage().DebugRoute.click();
-        BrowserUtils.waitForPageToLoad(10);
-    }
-    @Then("I should get five options")
-    public void i_should_get_five_options() {
-        Assert.assertTrue(new IpvCoreFrontPage().AddressStub.isDisplayed());
-    }
     @When("I click on Address\\(Stub)")
     public void i_click_on_address_stub() {
         new IpvCoreFrontPage().AddressStub.click();
         BrowserUtils.waitForPageToLoad(10);
     }
+
     @When("I supply my data in JSON format")
     public void i_supply_my_data_in_json_format() {
         myData = "{\"Hakan\":\"1234\"}";
         new SupplyDataPage().supplyDataInJSONFormatBox.sendKeys(myData);
         BrowserUtils.waitForPageToLoad(10);
     }
+
     @When("I click on Submit data and generate auth code")
     public void i_click_on_submit_data_and_generate_auth_code() {
         new SupplyDataPage().SubmitDataAndGenerateAuthCode.click();
         BrowserUtils.waitForPageToLoad(10);
-
-
     }
-    @Then("I should see GPG45 Score displayed")
-    public void i_should_see_gpg45_score_displayed() {
-        Assert.assertTrue(new IpvCoreFrontPage().CredentialAttributes.isDisplayed());
-    }
-    @When("I click on Authorize and Return")
-    public void i_click_on_authorize_and_return() {
-        new IpvCoreFrontPage().AuthorizeAndReturn.click();
-        BrowserUtils.waitForPageToLoad(10);
-    }
-    @Then("I should see User information displayed")
-    public void i_should_see_user_information_displayed() {
-        Assert.assertTrue(new UserInformationPage().VerifiableCredential.isDisplayed());
-    }
-    @When("I click on Verifiable Credentials")
-    public void i_click_on_verifiable_credentials() {
-        new UserInformationPage().VerifiableCredential.click();
-        BrowserUtils.waitForPageToLoad(10);
-    }
-    @Then("I should see my data in JSON payload")
-    public void i_should_see_my_data_in_json_payload() {
-        String payload =new UserInformationPage().VerifiableCredentialJSONPayload.getText();
-        System.out.println("payload = " + payload);
-        Boolean visibilityOfName = payload.contains("Hakan");
-        System.out.println("visibilityOfName = " + visibilityOfName);
-        Assert.assertTrue(payload.contains("Hakan"));
-    }
-
-
 }

--- a/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
@@ -1,0 +1,77 @@
+package gov.di_ipv_core.step_definitions;
+
+import gov.di_ipv_core.pages.IpvCoreFrontPage;
+import gov.di_ipv_core.pages.OrchestratorStubPage;
+import gov.di_ipv_core.pages.PassportPage;
+import gov.di_ipv_core.pages.UserInformationPage;
+import gov.di_ipv_core.utilities.BrowserUtils;
+import gov.di_ipv_core.utilities.ConfigurationReader;
+import gov.di_ipv_core.utilities.Driver;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.Assert;
+
+import static org.junit.Assert.assertEquals;
+
+public class CommonSmokeSteps {
+    public static final String CORE_FRONT_DEBUG_H1 = "di-ipv-core-front";
+
+    @Given("I am on Orchestrator Stub")
+    public void i_am_on_orchestrator_stub() {
+        Driver.get().get(ConfigurationReader.getOrchestratorUrl());
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @When("I click on Debug route")
+    public void i_click_on_debug_route() {
+        new OrchestratorStubPage().DebugRoute.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @Then("I should get five options")
+    public void i_should_get_five_options() {
+        Assert.assertTrue(new IpvCoreFrontPage().AddressStub.isDisplayed());
+    }
+
+    @When("I click continue")
+    public void clickContinue() {
+        new PassportPage().Continue.click();
+    }
+
+    @When("I should be on the core front debug page")
+    public void checkH1() {
+        assertEquals(CORE_FRONT_DEBUG_H1, new IpvCoreFrontPage().h1.getText());
+    }
+
+    @Then("I should see GPG45 Score displayed")
+    public void i_should_see_gpg45_score_displayed() {
+        Assert.assertTrue(new IpvCoreFrontPage().CredentialAttributes.isDisplayed());
+    }
+
+    @When("I click on Authorize and Return")
+    public void i_click_on_authorize_and_return() {
+        new IpvCoreFrontPage().AuthorizeAndReturn.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @Then("I should see User information displayed")
+    public void i_should_see_user_information_displayed() {
+        Assert.assertTrue(new UserInformationPage().VerifiableCredential.isDisplayed());
+    }
+
+    @When("I click on Verifiable Credentials")
+    public void i_click_on_verifiable_credentials() {
+        new UserInformationPage().VerifiableCredential.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @Given("I should see {} in the JSON payload")
+    public void i_should_see_my_data_in_json_payload(String name) {
+        String payload =new UserInformationPage().VerifiableCredentialJSONPayload.getText();
+        System.out.println("payload = " + payload);
+        boolean visibilityOfName = payload.contains(name);
+        System.out.println("visibilityOfName = " + visibilityOfName);
+        Assert.assertTrue(visibilityOfName);
+    }
+}

--- a/src/test/java/gov/di_ipv_core/step_definitions/PassportCriSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/PassportCriSmokeSteps.java
@@ -1,0 +1,43 @@
+package gov.di_ipv_core.step_definitions;
+
+import gov.di_ipv_core.pages.IpvCoreFrontPage;
+import gov.di_ipv_core.pages.PassportPage;
+import gov.di_ipv_core.utilities.BrowserUtils;
+import io.cucumber.java.en.When;
+
+import static org.junit.Assert.assertEquals;
+
+public class PassportCriSmokeSteps {
+
+    public static final String EXPIRY_MONTH = "03";
+    public static final String EXPIRY_YEAR = "2021";
+    private static final String PASSPORT_NUMBER = "824159121";
+    public static final String SURNAME = "Watson";
+    public static final String FIRST_NAME = "Mary";
+    public static final String BIRTH_DAY = "25";
+    public static final String BIRTH_MONTH = "02";
+    public static final String BIRTH_YEAR = "1932";
+    public static final String EXPIRY_DAY = "01";
+
+    @When("I click on ukPassport")
+    public void clickOnUkPassport() {
+        new IpvCoreFrontPage().UkPassport.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @When("I fill in my details")
+    public void fillInPassportDetails() {
+        PassportPage passportPage = new PassportPage();
+
+        passportPage.PassportNumber.sendKeys(PASSPORT_NUMBER);
+        passportPage.Surname.sendKeys(SURNAME);
+        passportPage.FirstName.sendKeys(FIRST_NAME);
+        passportPage.birthDay.sendKeys(BIRTH_DAY);
+        passportPage.birthMonth.sendKeys(BIRTH_MONTH);
+        passportPage.birthYear.sendKeys(BIRTH_YEAR);
+        passportPage.PassportExpiryDay.sendKeys(EXPIRY_DAY);
+        passportPage.PassportExpiryMonth.sendKeys(EXPIRY_MONTH);
+        passportPage.PassportExpiryYear.sendKeys(EXPIRY_YEAR);
+    }
+}
+

--- a/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
@@ -20,7 +20,7 @@ public class PassportSteps {
     public void user_enters_and(String passportNumber, String surname, String name, String birthDay, String birthMonth, String birthYear, String expiryDay, String expiryMonth, String expiryYear) {
         new PassportPage().PassportNumber.sendKeys(passportNumber);
         new PassportPage().Surname.sendKeys(surname);
-        new PassportPage().GivenNames.sendKeys(name);
+        new PassportPage().FirstName.sendKeys(name);
         new PassportPage().birthDay.sendKeys(birthDay);
         new PassportPage().birthMonth.sendKeys(birthMonth);
         new PassportPage().birthYear.sendKeys(birthYear);

--- a/src/test/resources/features/addressStubSmoke.feature
+++ b/src/test/resources/features/addressStubSmoke.feature
@@ -12,7 +12,7 @@ Feature: Full journey on Address Stub
     When I click on Authorize and Return
     Then I should see User information displayed
     When I click on Verifiable Credentials
-    Then I should see my data in JSON payload
+    Then I should see Hakan in the JSON payload
 
 
 

--- a/src/test/resources/features/passportCriSmoke.feature
+++ b/src/test/resources/features/passportCriSmoke.feature
@@ -1,0 +1,16 @@
+@passportSmoke
+Feature: Full journey with UK Passport CRI
+
+  Scenario: Successful journey
+    Given I am on Orchestrator Stub
+    When I click on Debug route
+    Then I should get five options
+    When I click on ukPassport
+    And I fill in my details
+    And I click continue
+    Then I should be on the core front debug page
+    And I should see GPG45 Score displayed
+    When I click on Authorize and Return
+    Then I should see User information displayed
+    When I click on Verifiable Credentials
+    Then I should see Mary in the JSON payload


### PR DESCRIPTION
This adds a new end to end smoke test that will exercise the passport
CRI in staging.

It also refactors some of the steps for the address stub smoke test into
a shared class. They're also used by the new smoke test.