### PR TITLE
PYIC-890: smoke tests for passport build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -54,10 +54,11 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
       - name: Test image
         env:
+          CORE_STUB_URL: https://build-passport-core-stub.london.cloudapps.digital/credential-issuers
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital
           BROWSER: chrome-headless
           NO_CHROME_SANDBOX: true
-        run: docker run -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew addressStubSmoke
+        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew addressStubSmoke passportCriSmokeBuild passportCriSmokeStaging
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -77,13 +77,24 @@ task addressStubSmoke() {
     }
 }
 
-task passportCriSmoke() {
+task passportCriSmokeBuild() {
     dependsOn assemble, compileTestJava
     doLast {
         javaexec {
             main = "io.cucumber.core.cli.Main"
             classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
-            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@passportSmoke']
+            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@passportSmokeBuild']
+        }
+    }
+}
+
+task passportCriSmokeStaging() {
+    dependsOn assemble, compileTestJava
+    doLast {
+        javaexec {
+            main = "io.cucumber.core.cli.Main"
+            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
+            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@passportSmokeStaging' ]
         }
     }
 }

--- a/src/test/java/gov/di_ipv_core/pages/CoreStubCrisPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/CoreStubCrisPage.java
@@ -1,0 +1,15 @@
+package gov.di_ipv_core.pages;
+
+import gov.di_ipv_core.utilities.Driver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class CoreStubCrisPage {
+    public CoreStubCrisPage(){
+        PageFactory.initElements(Driver.get(), this);
+    }
+
+    @FindBy(xpath = "//input[@value='Build Passport']")
+    public WebElement BuildPassportLink;
+}

--- a/src/test/java/gov/di_ipv_core/pages/CoreStubUserSearchPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/CoreStubUserSearchPage.java
@@ -1,0 +1,19 @@
+package gov.di_ipv_core.pages;
+
+import gov.di_ipv_core.utilities.Driver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class CoreStubUserSearchPage {
+    public CoreStubUserSearchPage(){
+        PageFactory.initElements(Driver.get(), this);
+    }
+
+    @FindBy(id = "rowNumber")
+    public WebElement rowNumberBox;
+
+    @FindBy(xpath = "//form[@action='/authorize']/div/button")
+    public WebElement goToBuildPassportButton;
+
+}

--- a/src/test/java/gov/di_ipv_core/pages/CoreStubVerifiableCredentialsPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/CoreStubVerifiableCredentialsPage.java
@@ -1,0 +1,22 @@
+package gov.di_ipv_core.pages;
+
+import gov.di_ipv_core.utilities.Driver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+
+public class CoreStubVerifiableCredentialsPage {
+    public CoreStubVerifiableCredentialsPage(){
+        PageFactory.initElements(Driver.get(), this);
+    }
+
+    @FindBy(xpath = "//h1")
+    public WebElement h1;
+
+    @FindBy (xpath = "//span[@class='govuk-details__summary-text']")
+    public WebElement response;
+
+    @FindBy(id = "data")
+    public WebElement jsonData;
+
+}

--- a/src/test/java/gov/di_ipv_core/step_definitions/PassportCriSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/PassportCriSmokeSteps.java
@@ -1,11 +1,19 @@
 package gov.di_ipv_core.step_definitions;
 
+import gov.di_ipv_core.pages.CoreStubCrisPage;
+import gov.di_ipv_core.pages.CoreStubUserSearchPage;
+import gov.di_ipv_core.pages.CoreStubVerifiableCredentialsPage;
 import gov.di_ipv_core.pages.IpvCoreFrontPage;
 import gov.di_ipv_core.pages.PassportPage;
 import gov.di_ipv_core.utilities.BrowserUtils;
+import gov.di_ipv_core.utilities.ConfigurationReader;
+import gov.di_ipv_core.utilities.Driver;
+import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class PassportCriSmokeSteps {
 
@@ -18,6 +26,35 @@ public class PassportCriSmokeSteps {
     public static final String BIRTH_MONTH = "02";
     public static final String BIRTH_YEAR = "1932";
     public static final String EXPIRY_DAY = "01";
+
+    @When("I start at the core stub")
+    public void startCoreStub() {
+        Driver.get().get(ConfigurationReader.getCoreStubUrl());
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @When("I click on Build Passport")
+    public void clickOnBuildPassport() {
+        new CoreStubCrisPage().BuildPassportLink.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @When("I enter '{}' in the Row Number box")
+    public void enterRowNumber(String rowNumber) {
+        new CoreStubUserSearchPage().rowNumberBox.sendKeys(rowNumber);
+    }
+
+    @When("I click on Go to Build Passport")
+    public void clickOnGoToBuildPassport() {
+        new CoreStubUserSearchPage().goToBuildPassportButton.click();
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @Then("I should be on the passport details page")
+    public void passportDetailsConfirm() {
+        assertTrue(Driver.get().getCurrentUrl().endsWith("/passport/details"));
+    }
+
 
     @When("I click on ukPassport")
     public void clickOnUkPassport() {
@@ -38,6 +75,20 @@ public class PassportCriSmokeSteps {
         passportPage.PassportExpiryDay.sendKeys(EXPIRY_DAY);
         passportPage.PassportExpiryMonth.sendKeys(EXPIRY_MONTH);
         passportPage.PassportExpiryYear.sendKeys(EXPIRY_YEAR);
+    }
+
+    @Then("I should be on the core stub Verifiable Credentials page")
+    public void coreStubVcPageConfirm() {
+        assertEquals("Verifiable Credentials", new CoreStubVerifiableCredentialsPage().h1.getText());
+    }
+
+    @Then("I should see Missing part delimiters displayed")
+    public void missingPartDelimiters() {
+        // This is just testing the error that passport CRI is currently returning due to it not inplementing
+        // the correct interface the core expects. This will be updated when passport is fixed.
+        CoreStubVerifiableCredentialsPage coreStubVerifiableCredentialsPage = new CoreStubVerifiableCredentialsPage();
+        coreStubVerifiableCredentialsPage.response.click();
+        assertTrue(coreStubVerifiableCredentialsPage.jsonData.getText().contains("Missing part delimiters"));
     }
 }
 

--- a/src/test/java/gov/di_ipv_core/utilities/ConfigurationReader.java
+++ b/src/test/java/gov/di_ipv_core/utilities/ConfigurationReader.java
@@ -34,12 +34,19 @@ public class ConfigurationReader {
     }
 
     public static String getOrchestratorUrl() {
-
         String orchestratorStubUrl = System.getenv("ORCHESTRATOR_STUB_URL");
         if (orchestratorStubUrl == null) {
             throw new IllegalArgumentException("Environment variable ORCHESTRATOR_STUB_URL is not set");
         }
         return orchestratorStubUrl;
+    }
+
+    public static String getCoreStubUrl() {
+        String coreStubUrl = System.getenv("CORE_STUB_URL");
+        if (coreStubUrl == null) {
+            throw new IllegalArgumentException("Environment variable CORE_STUB_URL is not set");
+        }
+        return coreStubUrl;
     }
 
     public static boolean noChromeSandbox() {

--- a/src/test/resources/features/passportCriSmoke.feature
+++ b/src/test/resources/features/passportCriSmoke.feature
@@ -1,7 +1,19 @@
-@passportSmoke
 Feature: Full journey with UK Passport CRI
 
-  Scenario: Successful journey
+  @passportSmokeBuild
+  Scenario: Successful journey from core stub
+    Given I start at the core stub
+    And I click on Build Passport
+    And I enter '3' in the Row Number box
+    And I click on Go to Build Passport
+    Then I should be on the passport details page
+    When I fill in my details
+    And I click continue
+    Then I should be on the core stub Verifiable Credentials page
+    And I should see Missing part delimiters displayed
+
+  @assportSmokeStaging
+  Scenario: Successful journey from core
     Given I am on Orchestrator Stub
     When I click on Debug route
     Then I should get five options


### PR DESCRIPTION
Adds a new cucumber feature for testing the passport CRI in staging,
which is now connected to the core stub. This will be run in pipeline
after a deploy of the passport CRI to the build environment.