### PR TITLE
BAU: Update stub smoke test to use the kbv stub

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,7 +58,7 @@ jobs:
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital
           BROWSER: chrome-headless
           NO_CHROME_SANDBOX: true
-        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew addressStubSmoke passportCriSmokeBuild passportCriSmokeStaging
+        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew kbvStubSmoke passportCriSmokeBuild passportCriSmokeStaging
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/dailySmokeTest.yml
+++ b/.github/workflows/dailySmokeTest.yml
@@ -26,8 +26,8 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-      - name: Run Address Smoke test against build environment
+      - name: Run Kbv Smoke test against build environment
         env:
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital/
           BROWSER: chrome-headless
-        run: gradle addressStubSmoke
+        run: gradle kbvStubSmoke

--- a/.github/workflows/gradleBuildTest.yml
+++ b/.github/workflows/gradleBuildTest.yml
@@ -25,9 +25,9 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-      - name: Run Address Smoke test against build environment
+      - name: Run Kbv Smoke test against build environment
         env:
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital/
           BROWSER: chrome-headless
-        run: gradle addressStubSmoke
+        run: gradle kbvStubSmoke
 

--- a/build.gradle
+++ b/build.gradle
@@ -78,13 +78,13 @@ task cucumber() {
     }
 }
 
-task addressStubSmoke() {
+task kbvStubSmoke() {
     dependsOn assemble, compileTestJava
     doLast {
         javaexec {
             main = "io.cucumber.core.cli.Main"
             classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
-            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@address_smoke']
+            args = ['--plugin', 'pretty', '--glue', 'gov/di_ipv_core/step_definitions', 'src/test/resources/features/', '--tags', '@kbv_smoke']
         }
     }
 }

--- a/src/test/java/gov/di_ipv_core/pages/AddressStubPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/AddressStubPage.java
@@ -1,6 +1,5 @@
 package gov.di_ipv_core.pages;
 
-import com.github.dockerjava.core.dockerfile.DockerfileStatement;
 import gov.di_ipv_core.utilities.Driver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -11,11 +10,9 @@ public class AddressStubPage {
         PageFactory.initElements(Driver.get(), this);
     }
 
-    @FindBy (id ="jsonPayload")
+    @FindBy(id ="jsonPayload")
     public WebElement JSONPayLoader;
 
     @FindBy (xpath = "//input[@name='submit']")
     public WebElement SubmitDataAndGenerateAuthCode;
-
-
 }

--- a/src/test/java/gov/di_ipv_core/pages/IpvCoreFrontPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/IpvCoreFrontPage.java
@@ -14,8 +14,8 @@ public class IpvCoreFrontPage {
     @FindBy (xpath = "//h1")
     public WebElement h1;
 
-    @FindBy (xpath = "//a[normalize-space()='Address (Stub)']")
-    public WebElement AddressStub;
+    @FindBy (xpath = "//a[normalize-space()='KBV (Stub)']")
+    public WebElement KbvStub;
 
     @FindBy (xpath = "//a[normalize-space()='ukPassport']")
     public WebElement UkPassport;

--- a/src/test/java/gov/di_ipv_core/pages/SupplyDataPage.java
+++ b/src/test/java/gov/di_ipv_core/pages/SupplyDataPage.java
@@ -13,6 +13,9 @@ public class SupplyDataPage {
     @FindBy (id = "jsonPayload")
     public WebElement supplyDataInJSONFormatBox;
 
+    @FindBy (id = "verification")
+    public WebElement supplyGpg45VerificationValue;
+
     @FindBy (xpath = "//input[@name='submit']")
     public WebElement SubmitDataAndGenerateAuthCode;
 }

--- a/src/test/java/gov/di_ipv_core/step_definitions/KbvStubSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/KbvStubSmokeSteps.java
@@ -1,24 +1,16 @@
 package gov.di_ipv_core.step_definitions;
 
 import gov.di_ipv_core.pages.IpvCoreFrontPage;
-import gov.di_ipv_core.pages.OrchestratorStubPage;
 import gov.di_ipv_core.pages.SupplyDataPage;
-import gov.di_ipv_core.pages.UserInformationPage;
 import gov.di_ipv_core.utilities.BrowserUtils;
-import gov.di_ipv_core.utilities.ConfigurationReader;
-import gov.di_ipv_core.utilities.Driver;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.Assert;
 
-public class AddressStubSmokeSteps {
-
+public class KbvStubSmokeSteps {
     String myData;
 
-    @When("I click on Address\\(Stub)")
-    public void i_click_on_address_stub() {
-        new IpvCoreFrontPage().AddressStub.click();
+    @When("I click on Kbv\\(Stub)")
+    public void i_click_on_kbv_stub() {
+        new IpvCoreFrontPage().KbvStub.click();
         BrowserUtils.waitForPageToLoad(10);
     }
 
@@ -26,6 +18,13 @@ public class AddressStubSmokeSteps {
     public void i_supply_my_data_in_json_format() {
         myData = "{\"Hakan\":\"1234\"}";
         new SupplyDataPage().supplyDataInJSONFormatBox.sendKeys(myData);
+        BrowserUtils.waitForPageToLoad(10);
+    }
+
+    @When("I supply my gpg45 verification value")
+    public void i_supply_my_gpg45_verification_value() {
+        myData = "2";
+        new SupplyDataPage().supplyGpg45VerificationValue.sendKeys(myData);
         BrowserUtils.waitForPageToLoad(10);
     }
 

--- a/src/test/resources/features/kbvStubSmoke.feature
+++ b/src/test/resources/features/kbvStubSmoke.feature
@@ -1,12 +1,13 @@
-@address_smoke
-Feature: Full journey on Address Stub
+@kbv_smoke
+Feature: Full journey on Kbv Stub
 
-  Scenario: Test full Address Stub UI journey
+  Scenario: Test full Kbv Stub UI journey
     Given I am on Orchestrator Stub
     When I click on Debug route
     Then I should get five options
-    When I click on Address(Stub)
+    When I click on Kbv(Stub)
     And I supply my data in JSON format
+    And I supply my gpg45 verification value
     And I click on Submit data and generate auth code
     Then I should see GPG45 Score displayed
     When I click on Authorize and Return


### PR DESCRIPTION
The "address stub" smoke test now fails in the staging environment. This is because in the staging environment we now use the real version of the address CRI.

To fix this I've just swapped things around to now use the kbv stub cri, so I've updated the address cucumber feature to now use the kbv stub in its test journey.