### PR TITLE
BAU: Fix image build GitHub workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - src
+      - src/**
       - .github/workflows/build-image.yml
       - Dockerfile
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -8,9 +8,6 @@ on:
       - src
       - .github/workflows/build-image.yml
       - Dockerfile
-  registry_package:
-    types:
-      - updated
 
   workflow_dispatch:
     inputs:
@@ -52,13 +49,19 @@ jobs:
           context: .
           load: true
           tags: ${{ steps.tags.outputs.tags }}
-      - name: Test image
+      - name: Test image in build environment
         env:
           CORE_STUB_URL: https://build-passport-core-stub.london.cloudapps.digital/credential-issuers
           ORCHESTRATOR_STUB_URL: https://build-di-ipv-orchestrator-stub.london.cloudapps.digital
           BROWSER: chrome-headless
           NO_CHROME_SANDBOX: true
-        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew kbvStubSmoke passportCriSmokeBuild passportCriSmokeStaging
+        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew kbvStubSmoke passportCriSmokeBuild
+      - name: Test image in staging environment
+        env:
+          ORCHESTRATOR_STUB_URL: https://staging-di-ipv-orchestrator-stub.london.cloudapps.digital
+          BROWSER: chrome-headless
+          NO_CHROME_SANDBOX: true
+        run: docker run -e CORE_STUB_URL -e ORCHESTRATOR_STUB_URL -e BROWSER -e NO_CHROME_SANDBOX "${GHCR_REPO}":latest ./gradlew kbvStubSmoke passportCriSmokeStaging
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION
We have different smokes tests that should be run in different
environments. They need different values for the same configuration to
work properly in their respective environments. This splits the testing
of the smoke tests into two jobs with the appropriate config set.

It also removes the trigger for the registry_package. The workflow
is failing to trigger on a merge to main, and this might be the culprit.
We don't really need it anyway so it's gone in the 🗑.