### PR TITLE
BAU Fix Passport CRI Smoke Test

### DIFF
--- a/src/test/resources/features/passportCriSmoke.feature
+++ b/src/test/resources/features/passportCriSmoke.feature
@@ -16,7 +16,6 @@ Feature: Full journey with UK Passport CRI
   Scenario: Successful journey from core
     Given I am on Orchestrator Stub
     When I click on Debug route
-    Then I should get five options
     When I click on ukPassport
     And I fill in my details
     And I click continue


### PR DESCRIPTION
Remove the assertion of seeing five options on the core page because
that is no longer true as per guidance from Hakan.

This test now works when I run it locally.