### PR TITLE
BAU Fix Clean up and Tear Down Hooks

### DIFF
--- a/src/test/java/gov/di_ipv_core/step_definitions/Hooks.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/Hooks.java
@@ -1,5 +1,6 @@
 package gov.di_ipv_core.step_definitions;
 
+import gov.di_ipv_core.utilities.ConfigurationReader;
 import gov.di_ipv_core.utilities.Driver;
 import io.cucumber.java.After;
 import io.cucumber.java.AfterAll;
@@ -12,13 +13,11 @@ public class Hooks {
 
     @Before("@integration_test")
     public void clearS3Bucket() {
-        final String BUCKET_NAME = "staging-smoke-test-sms-codes";
-        final String OBJECT_NAME = "+447700900222";
         S3Client s3Client = S3Client.builder().region(Region.EU_WEST_2).build();
         s3Client.deleteObject(DeleteObjectRequest
                 .builder()
-                .bucket(BUCKET_NAME)
-                .key(OBJECT_NAME)
+                .bucket(ConfigurationReader.getAuthCodeBucketName())
+                .key(ConfigurationReader.getAuthCodeKeyName())
                 .build());
 
     }
@@ -30,8 +29,8 @@ public class Hooks {
         S3Client s3Client = S3Client.builder().region(Region.EU_WEST_2).build();
         s3Client.deleteObject(DeleteObjectRequest
                 .builder()
-                .bucket(BUCKET_NAME)
-                .key(OBJECT_NAME)
+                .bucket(ConfigurationReader.getAuthCodeBucketName())
+                .key(ConfigurationReader.getAuthCodeKeyName())
                 .build());
     }
 

--- a/src/test/java/gov/di_ipv_core/step_definitions/IntegrationSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/IntegrationSteps.java
@@ -216,8 +216,3 @@ public class IntegrationSteps {
         BrowserUtils.waitFor(2);
     }
 }
-
-
-
-
-


### PR DESCRIPTION
These hooks should take the bucket name and key for the AUTH code from
the environment variables.

### What
This should address the issues with: https://cd.gds-reliability.engineering/teams/di-ipv/pipelines/core-deploy-to-integration/jobs/run-smoke-tests/builds/170#L62ada469:59 and https://cd.gds-reliability.engineering/teams/di-ipv/pipelines/core-deploy-to-integration/jobs/run-smoke-tests/builds/170#L62ada469:119

We need to run the `./gradlew integrationTest` on PRs but we'll need to get the GHA access to the Auth bucket so we'll tackle that separately. For now the goal is to get these tests running in our integration pipeline.