### PR TITLE
BAU Update configuration for waiting on Auth Key

### DIFF
--- a/src/test/java/gov/di_ipv_core/step_definitions/IntegrationSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/IntegrationSteps.java
@@ -110,7 +110,6 @@ public class IntegrationSteps {
                 WaiterOverrideConfiguration
                         .builder()
                         .backoffStrategy(BackoffStrategy.defaultStrategy())
-                        .maxAttempts(10)
                         .waitTimeout(Duration.of(3, ChronoUnit.MINUTES))
                         .build()).matched();
 


### PR DESCRIPTION
Configure the waiter to wait up to 3 minutes for the Auth key to appear
in the S3 bucket. It seems if the `maxAttempts` is also specified then
it stops when the max attempts is reached regardless of whether the
timeout has been breached.