### PR TITLE
Passport Escape Route Retry Tests

### DIFF
--- a/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
@@ -2,7 +2,6 @@ package gov.di_ipv_core.step_definitions;
 
 import gov.di_ipv_core.pages.*;
 import gov.di_ipv_core.utilities.BrowserUtils;
-import gov.di_ipv_core.utilities.ConfigurationReader;
 import gov.di_ipv_core.utilities.Driver;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -19,7 +18,7 @@ public class CommonSmokeSteps {
 
     @Given("I am on Orchestrator Stub")
     public void i_am_on_orchestrator_stub() {
-        Driver.get().get(ConfigurationReader.getOrchestratorUrl());
+        Driver.get().get("https://staging-di-ipv-orchestrator-stub.london.cloudapps.digital");
         BrowserUtils.waitForPageToLoad(10);
     }
 

--- a/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/CommonSmokeSteps.java
@@ -2,6 +2,7 @@ package gov.di_ipv_core.step_definitions;
 
 import gov.di_ipv_core.pages.*;
 import gov.di_ipv_core.utilities.BrowserUtils;
+import gov.di_ipv_core.utilities.ConfigurationReader;
 import gov.di_ipv_core.utilities.Driver;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -18,7 +19,7 @@ public class CommonSmokeSteps {
 
     @Given("I am on Orchestrator Stub")
     public void i_am_on_orchestrator_stub() {
-        Driver.get().get("https://staging-di-ipv-orchestrator-stub.london.cloudapps.digital");
+        Driver.get().get(ConfigurationReader.getOrchestratorUrl());
         BrowserUtils.waitForPageToLoad(10);
     }
 

--- a/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
@@ -111,12 +111,6 @@ public class PassportSteps {
         new PassportPage().PassportExpiryYear.sendKeys(passportSubject.getexpiryYear());
     }
 
-    @Then("proper error message for could not find details on retry is displayed")
-    public void properErrorMessageForCouldNotFindDetailsOnRetryIsDisplayed() {
-        BrowserUtils.waitForPageToLoad(10);
-        Assert.assertEquals("Sorry, we cannot prove your identity right now",new PassportPage().Passportnotfoundonretry.getText());
-    }
-
     @Given("User click on ‘prove your identity another way' Link")
     public void userClickOnProveYourIdentityAnotherWayLink() {
         new PassportPage().proveanotherway.click();
@@ -143,5 +137,11 @@ public class PassportSteps {
     @Then("User should be redirected back to passport page")
     public void userShouldBeRedirectedBackToPassportPage() {
         Assert.assertTrue(new EnterYourDetailsExactlyPage().PassportNumber.isDisplayed());
+    }
+
+    @Then("Then the Sorry, we cannot prove your identity right now error page is displayed")
+    public void thenTheSorryWeCannotProveYourIdentityRightNowErrorPageIsDisplayed() {
+            BrowserUtils.waitForPageToLoad(10);
+            Assert.assertEquals("Sorry, we cannot prove your identity right now",new PassportPage().Passportnotfoundonretry.getText());
     }
 }

--- a/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/PassportSteps.java
@@ -114,7 +114,7 @@ public class PassportSteps {
     @Then("proper error message for could not find details on retry is displayed")
     public void properErrorMessageForCouldNotFindDetailsOnRetryIsDisplayed() {
         BrowserUtils.waitForPageToLoad(10);
-        Assert.assertTrue(new PassportPage().Passportnotfoundonretry.isDisplayed());
+        Assert.assertEquals("Sorry, we cannot prove your identity right now",new PassportPage().Passportnotfoundonretry.getText());
     }
 
     @Given("User click on ‘prove your identity another way' Link")

--- a/src/test/java/gov/di_ipv_core/step_definitions/UkPassportSteps.java
+++ b/src/test/java/gov/di_ipv_core/step_definitions/UkPassportSteps.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gov.di_ipv_core.pages.IpvCoreFrontPage;
 import gov.di_ipv_core.pages.UserInformationPage;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import org.junit.Assert;
 
@@ -36,4 +35,7 @@ public class UkPassportSteps {
         Assert.assertTrue(new UserInformationPage().VerifiableCredential.isDisplayed());
     }
 
+    @Then("Then the {string} error page is displayed")
+    public void thenTheSorryWeCannotProveYourIdentityRightNowErrorPageIsDisplayed() {
+    }
 }

--- a/src/test/resources/features/passport.feature
+++ b/src/test/resources/features/passport.feature
@@ -138,7 +138,7 @@ Feature: Passport Test
     Then User should be redirected back to passport page
     When user Re-enters data as a <PassportSubject>
     And user clicks on continue
-    Then proper error message for could not find details on retry is displayed
+    Then Then the Sorry, we cannot prove your identity right now error page is displayed
     Examples:
       |PassportSubject             |
       |InvalidPassport             |

--- a/src/test/resources/features/passport.feature
+++ b/src/test/resources/features/passport.feature
@@ -111,3 +111,34 @@ Feature: Passport Test
     Examples:
       |PassportSubject             |
       |PassportSubjectHappyDanny   |
+
+  @passport_test @PYIC-1636
+  Scenario Outline: Passport Escape Route 2nd retry Happy Path
+    Given user enters invalid passport details
+    When user clicks on continue
+    Then proper error message for could not find details is displayed
+    When User click on ‘prove your identity another way' Link
+    And user click on Enter passport details to prove identity radio button
+    Then User should be redirected back to passport page
+    When user Re-enters data as a <PassportSubject>
+    And user clicks on continue
+    Then I should see validity score 2 in the JSON payload
+    And I should see Strength score 4 in the JSON payload
+    Examples:
+      |PassportSubject             |
+      |PassportSubjectHappyDanny   |
+
+  @passport_test @PYIC-1636
+  Scenario Outline: Passport Escape Route 2nd retry Unhappy Path
+    Given user enters invalid passport details
+    When user clicks on continue
+    Then proper error message for could not find details is displayed
+    When User click on ‘prove your identity another way' Link
+    And user click on Enter passport details to prove identity radio button
+    Then User should be redirected back to passport page
+    When user Re-enters data as a <PassportSubject>
+    And user clicks on continue
+    Then proper error message for could not find details on retry is displayed
+    Examples:
+      |PassportSubject             |
+      |InvalidPassport             |


### PR DESCRIPTION
Proposed changes
What changed
New Tests to validate the feature for Passport Escape route retry second time tests covering test cases PYIC-1690 & PYIC-1691
Why did it change
To validate the passport CRI escape route second retry tests